### PR TITLE
:hammer_and_wrench: debounce-handler handle no prop case

### DIFF
--- a/packages/debounce-handler/src/index.js
+++ b/packages/debounce-handler/src/index.js
@@ -9,11 +9,15 @@ const debounceHandler = (handlerName, delay, leadingCall) => (Target) => {
 
       const delayValue = typeof delay === 'function' ? delay(props) : delay
 
-      this.debouncedPropInvoke = debounce(
-        (...args) => this.props[handlerName](...args),
-        delayValue,
-        leadingCall
-      )
+      if (this.props[handlerName]) {
+        this.debouncedPropInvoke = debounce(
+          (...args) => this.props[handlerName](...args),
+          delayValue,
+          leadingCall
+        )
+      } else {
+        this.debouncedPropInvoke = () => {}
+      }
 
       this.handler = (e, ...rest) => {
         if (e && typeof e.persist === 'function') {

--- a/packages/debounce-handler/test/index.js
+++ b/packages/debounce-handler/test/index.js
@@ -104,6 +104,15 @@ describe('debounceHandler', () => {
     expect(mockJustDebounce.mock.calls).toMatchSnapshot()
   })
 
+  it('should not error if prop is not present', () => {
+    const EnhancedTarget = debounceHandler('testHandler', 75, true)(Target)
+    const wrapper = mount(
+      <EnhancedTarget />
+    )
+    const testHandler = wrapper.find(Target).prop('testHandler')
+    testHandler()
+  })
+
   describe('display name', () => {
     const origNodeEnv = process.env.NODE_ENV
 


### PR DESCRIPTION
We are using debounce-handler to enhance a component with optional props, we would like to debounce them only if they are present. At the moment this results in an error (see test case).