### PR TITLE
Bugfix on with-callback-on-change for a non-update after a first update on props.

### DIFF
--- a/packages/with-callback-on-change/src/index.js
+++ b/packages/with-callback-on-change/src/index.js
@@ -6,6 +6,7 @@ const withCallbackOnChange = (propName, callback) => (Target) => {
     static getDerivedStateFromProps (nextProps, prevState) {
       if (prevState[propName] !== nextProps[propName]) {
         callback(nextProps)
+        return { [propName]: nextProps[propName] }
       }
 
       return null

--- a/packages/with-callback-on-change/test/index.js
+++ b/packages/with-callback-on-change/test/index.js
@@ -39,6 +39,19 @@ describe('withCallbackOnChange', () => {
     expect(mockCallback.mock.calls).toMatchSnapshot()
   })
 
+  it('should no-op if prop is the same after a first change', () => {
+    const mockCallback = jest.fn()
+    const EnhancedTarget = withCallbackOnChange('a', mockCallback)(Target)
+    const wrapper = mount(
+      <EnhancedTarget a={1} b={2} c={3} />
+    )
+
+    wrapper.setProps({ a: 2 })
+    expect(mockCallback.mock.calls.length).toBe(1)
+    wrapper.setProps({ b: 4 })
+    expect(mockCallback.mock.calls.length).toBe(1)
+  })
+
   describe('display name', () => {
     const origNodeEnv = process.env.NODE_ENV
 


### PR DESCRIPTION
Surely you can notice the bug when you look at the code update, but i will illustrate the bug:
Component with props ` { a: 1, b: 2 } `
-> `setProps on Component to { a: 2, b: 2 }`
-> `setProps on Component to { a: 2, b: 3 }`

The callback should have been called only one time (`a: 1` -> `a: 2`), but it is actually being called 2 times.

Commit notes:
- Updated with-callback-on-change HOC to update the new state, so when the prop is not updated after a first update it works as expected.
- Added test in order to cover this bugfix.